### PR TITLE
Cron jobs from Kubernetes

### DIFF
--- a/.ruby-gemset
+++ b/.ruby-gemset
@@ -1,1 +1,1 @@
-cron-kubernetes
+cron-kubernetes-ruby

--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ for a discussion of how `command` works in Kubernetes.
 
 ## Usage
 
+### Create a Schedule
 Add a file to your source that defines the scheduled tasks. If you are using Rails, you could 
 put this in `config/initializers/cron_kuberentes.rb`. Or, if you want to make it work like the
 `whenever` gem you could add these lines to `config/schedule.rb` and then `require` that from your
@@ -117,20 +118,49 @@ For all jobs you may provide a `name` to name, which will be used with the `iden
 CronJob. If you do not provide a name `CronKubernetes` will try to figure one out from the job and
 pod templates plus a hash of the schedule and command.
 
-### Shell Commands
+#### Shell Commands
 
 A `command` runs any arbitrary shell command on a schedule. The first argument is the command to run.
 
 
-### Rake Tasks
+#### Rake Tasks
 
 A `rake` call runs a `rake` task on the schedule. Rake and Bundler must be installed and on the path 
 in the container The command it executes is `bundle exec rake ...`. 
 
-### Runners
+#### Runners
 
 A `runner` runs arbitrary ruby code under rails. Rails must be installed at `bin/rails` from the 
 working folder. The command it executes is `bin/rails runner '...'`.
+
+### Update Your Cluster
+
+Once you have configuration and cluster, then you can run the `cron_kubernetes` command
+to update your cluster. 
+
+```bash
+cron_kubernetes --configuration config/initializers/cron_kubernetes.rb --schedule config/schedule.rb
+```
+
+The command will read the provided configuration and current schedule, compare to any 
+CronJobs already in your cluster for this project (base on the `identifier`) and then 
+add/remove/update the CronJobs to bring match the schedule.
+
+You can provide either `--configuration` or `--schedule`, as long as between the files you have 
+loaded both a configuration and a schedule. For example, if they are in the same file, you would
+just pass a single value:
+
+```bash
+cron_kubernetes --schedule schedule.rb
+``` 
+
+If you are running in a Rails application where the initializers are auto-loaded, and your 
+schedule is defined in (or in a file required by) your initializer, you could run this within
+your Rails environment:
+
+```bash
+bin/rails runner cron_kubernetes
+``` 
 
 ## To Do
 - In place of `schedule`, support `every`/`at` syntax:

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ and default values are shown below.
 CronKubernetes.configuration do |config|
   # Required
   config.identifier   = "my-application"
-  config.manifest     = YAML.read(File.join(Rails.root, "deploy", "kubernetes-job.yml"))
+  config.manifest     = YAML.load_file(File.join(Rails.root, "deploy", "kubernetes-job.yml"))
 
   # Optional
   config.output       = nil

--- a/README.md
+++ b/README.md
@@ -24,12 +24,52 @@ Or install it yourself as:
 You can configure global settings for your cron jobs. Add a file to your source as following. 
 If you are using Rails, you can add this to something like `config/initializers/cron_kuberentes.rb`.
 
+You _must_ configure the `manifest` setting. The other settings are optional and default values
+are shown below.
+
 ```ruby
 CronKubernetes.configure do |config|
-  config.manifest = YAML.read(File.join(Rails.root, "deploy", "kubernetes-cronjob.yml"))
-  config.output -> { "2>&1" }
+  config.manifest     = YAML.read(File.join(Rails.root, "deploy", "kubernetes-job.yml"))
+  config.output       = ""
+  config.job_template = "/bin/bash -l -c :job"
 end
 ```
+
+### `manifest`
+
+This is a Kubernetes Job manifest used as the job template within the Kubernetes 
+CronJob. That is, this is the job that's started at the specified schedule. For 
+example:
+
+```yaml
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: scheduled-job
+spec:
+  template:
+    metadata:
+      name: scheduled-job
+    spec:
+      containers:
+      - name: my-shell
+        image: ubuntu:latest
+```
+
+In the example above we show the manifest loading a file, just to make it
+simple. But you could also read use a HEREDOC, parse a template and insert
+values, or anything else you want to do in the method, as long as you return
+a valid Kubernetes Job manifest as a `Hash`.
+
+When the job is run, the default command in the Docker instance is replaced with
+the command specified in the cron schedule (see below).
+
+### `output`
+
+By default no rediction is done, so that cron behaves as normal. If you would like you 
+can specify an option here to redirect as you would on a shell command. For example,
+`"2>&1` to collect STDERR in STDOUT or `>> /var/log/task.log` to send to a log file.
+
 ## Usage
 
 Add a file to your source that defines the scheduled tasks. If you are using Rails, you can add
@@ -39,10 +79,19 @@ initializer.
 
 ```ruby
 CronKubernetes.schedule do
-  runner(schedule: "30 3 * * *") { CleanSweeper.run }
+  runner("CleanSweeper.run", schedule: "30 3 * * *")
   rake "audit:state", schedule: "0 20 1 * *"
 end
 ```
+
+## To Do
+- In place of `schedule`, support `every`/`at` syntax:
+  ```
+  every: :minute, :hour, :day, :month, :year
+         3.minutes, 1.hour, 1.day, 1.week, 1.month, 1.year
+  at: "[H]H:mm[am|pm]"
+  ```
+
 ## Development
 
 After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake spec` to run the tests. 
@@ -58,6 +107,12 @@ push git commits and tags, and push the `.gem` file to [rubygems.org](https://ru
 ## Contributing
 
 Bug reports and pull requests are welcome on GitHub at https://github.com/keylimetoolbox/cron-kubernetes.
+
+## Acknowledgments
+
+We have used the [`whenever` gem](https://github.com/javan/whenever) for years and we love it. 
+Much of the ideas for scheduling here were inspired by the great work that @javan and team 
+have put into that gem.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
 # CronKubernetes
 
-Configue and deploy Kubernetes [CronJobs](https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/) from 
-ruby. 
+Configue and deploy Kubernetes [CronJobs](https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/) 
+from ruby. 
 
 ## Installation
 
 Add this line to your application's Gemfile:
 
 ```ruby
-gem 'cron-kubernetes'
+gem "cron-kubernetes"
 ```
 
 And then execute:
@@ -19,17 +19,40 @@ Or install it yourself as:
 
     $ gem install cron_kubernetes
 
+## Configuration
+
+You can configure global settings for your cron jobs. Add a file to your source as following. 
+If you are using Rails, you can add this to something like `config/initializers/cron_kuberentes.rb`.
+
+```ruby
+CronKubernetes.configure do |config|
+  config.manifest = YAML.read(File.join(Rails.root, "deploy", "kubernetes-cronjob.yml"))
+  config.output -> { "2>&1" }
+end
+```
 ## Usage
 
-TODO: Write usage instructions here
+Add a file to your source that defines the scheduled tasks. If you are using Rails, you can add
+this to something like `config/initializers/cron_kuberentes.rb`. Or, if you are familiar with the
+`whenever` gem you could add these lines to `config/schedule.rb` and then `require` that from your
+initializer.
 
+```ruby
+CronKubernetes.schedule do
+  runner(schedule: "30 3 * * *") { CleanSweeper.run }
+  rake "audit:state", schedule: "0 20 1 * *"
+end
+```
 ## Development
 
-After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake spec` to run the tests. You can 
-also run `bin/console` for an interactive prompt that will allow you to experiment.
+After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake spec` to run the tests. 
 
-To install this gem onto your local machine, run `bundle exec rake install`. To release a new version, update the 
-version number in `version.rb`, and then run `bundle exec rake release`, which will create a git tag for the version, 
+You can also run `bin/console` for an interactive prompt that will allow you to experiment.
+
+To install this gem onto your local machine, run `bundle exec rake install`. 
+
+To release a new version, update the version number in `lib/cron_kubernets/version.rb` and the `CHANGELOG.md`, 
+and then run `bundle exec rake release`, which will create a git tag for the version, 
 push git commits and tags, and push the `.gem` file to [rubygems.org](https://rubygems.org).
 
 ## Contributing

--- a/bin/cron_kubernetes
+++ b/bin/cron_kubernetes
@@ -1,0 +1,29 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require "cron_kubernetes"
+require "optparse"
+
+# Support looking up Google Default Application Credentials, if the gem is installed
+begin
+  require "googleauth"
+rescue LoadError
+  nil
+end
+
+OptionParser.new do |opts|
+  opts.banner = "Usage: cron_kubernetes [options]"
+  opts.on("-c", "--configuration [file]", "Location of your configuration file") do |file|
+    require File.join(Dir.pwd, file) if file
+  end
+  opts.on("-c", "--schedule [file]", "Location of your schedule file") do |file|
+    require File.join(Dir.pwd, file) if file
+  end
+
+  opts.on("-v", "--version") do
+    puts "CronKubernetes v#{CronKubernetes::VERSION}"
+    exit(0)
+  end
+end.parse!
+
+CronKubernetes::CronTab.new.update

--- a/cron-kubernetes.gemspec
+++ b/cron-kubernetes.gemspec
@@ -19,9 +19,10 @@ Gem::Specification.new do |spec|
   spec.files         = `git ls-files -z`.split("\x0").reject do |f|
     f.match(%r{^(test|spec|features)/})
   end
-  spec.bindir        = "bin"
-  spec.executables   << "cron_kubernetes"
   spec.require_paths = ["lib"]
+
+  spec.bindir = "bin"
+  spec.executables << "cron_kubernetes"
 
   spec.add_dependency "kubeclient", "~> 3.0"
 

--- a/cron-kubernetes.gemspec
+++ b/cron-kubernetes.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.email         = ["jeremy.wadsack@gmail.com"]
 
   spec.summary       = "Configure and deploy Kubernetes CronJobs from ruby."
-  spec.description   = "Configure and deploy Kubernetes CronJobs from ruby"
+  spec.description   = "Configure and deploy Kubernetes CronJobs from ruby with a single schedule."
   spec.homepage      = "https://github.com/keylimetoolbox/cron-kubernetes"
   spec.license       = "MIT"
 
@@ -21,10 +21,15 @@ Gem::Specification.new do |spec|
   end
   spec.require_paths = ["lib"]
 
+  spec.add_dependency "kubeclient", "~> 3.0"
+
   spec.add_development_dependency "bundler", "~> 1.16"
   spec.add_development_dependency "bundler-audit", "~> 0"
   spec.add_development_dependency "mocha", "~> 1.3"
   spec.add_development_dependency "rake", "~> 12.3"
   spec.add_development_dependency "rspec", "~> 3.7"
   spec.add_development_dependency "rubocop", "~> 0.52", ">= 0.52.1"
+
+  # For connecting to a GKE cluster in development/test
+  spec.add_development_dependency "googleauth"
 end

--- a/cron-kubernetes.gemspec
+++ b/cron-kubernetes.gemspec
@@ -23,6 +23,7 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "bundler", "~> 1.16"
   spec.add_development_dependency "bundler-audit", "~> 0"
+  spec.add_development_dependency "mocha", "~> 1.3"
   spec.add_development_dependency "rake", "~> 12.3"
   spec.add_development_dependency "rspec", "~> 3.7"
   spec.add_development_dependency "rubocop", "~> 0.52", ">= 0.52.1"

--- a/cron-kubernetes.gemspec
+++ b/cron-kubernetes.gemspec
@@ -19,6 +19,8 @@ Gem::Specification.new do |spec|
   spec.files         = `git ls-files -z`.split("\x0").reject do |f|
     f.match(%r{^(test|spec|features)/})
   end
+  spec.bindir        = "bin"
+  spec.executables   << "cron_kubernetes"
   spec.require_paths = ["lib"]
 
   spec.add_dependency "kubeclient", "~> 3.0"

--- a/lib/cron-kubernetes.rb
+++ b/lib/cron-kubernetes.rb
@@ -1,0 +1,1 @@
+require "cron_kubernetes"

--- a/lib/cron_kubernetes.rb
+++ b/lib/cron_kubernetes.rb
@@ -2,6 +2,9 @@
 
 require "cron_kubernetes/configurable"
 require "cron_kubernetes/cron_job"
+require "cron_kubernetes/cron_tab"
+require "cron_kubernetes/kubeclient_context"
+require "cron_kubernetes/kubernetes_client"
 require "cron_kubernetes/scheduler"
 require "cron_kubernetes/version"
 
@@ -19,6 +22,9 @@ module CronKubernetes
   # You can alter this with your own template, add `:job` where the job should go.
   # Note that the job will be treated as a single shell argument or command.
   define_setting :job_template, %w[/bin/bash -l -c :job]
+
+  # Provide an identifier for this schedule (e.g. your application name)
+  define_setting :identifier
 
   class << self
     def schedule(&block)

--- a/lib/cron_kubernetes.rb
+++ b/lib/cron_kubernetes.rb
@@ -1,8 +1,27 @@
 # frozen_string_literal: true
 
+require "cron_kubernetes/configurable"
+require "cron_kubernetes/scheduler"
 require "cron_kubernetes/version"
 
 # Configure and deploy Kubernetes CronJobs from ruby
 module CronKubernetes
-  # Your code goes here...
+  extend Configurable
+
+  # Provide a CronJob manifest as a Hash
+  define_setting :manifest
+
+  # Provide shell output redirection (e.g. "2>&1" or ">> log")
+  define_setting :output
+
+  # For RVM support, and to load PATH and such, jobs are run through a bash shell.
+  # You can alter this with your own template, add `:job` where the job should go.
+  # Note that the job will be escaped.
+  define_setting :job_template, "/bin/bash -l -c :job"
+
+  class << self
+    def schedule(&block)
+      CronKubernetes::Scheduler.instance.instance_eval(&block)
+    end
+  end
 end

--- a/lib/cron_kubernetes.rb
+++ b/lib/cron_kubernetes.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "cron_kubernetes/configurable"
+require "cron_kubernetes/cron_job"
 require "cron_kubernetes/scheduler"
 require "cron_kubernetes/version"
 
@@ -16,8 +17,8 @@ module CronKubernetes
 
   # For RVM support, and to load PATH and such, jobs are run through a bash shell.
   # You can alter this with your own template, add `:job` where the job should go.
-  # Note that the job will be escaped.
-  define_setting :job_template, "/bin/bash -l -c :job"
+  # Note that the job will be treated as a single shell argument or command.
+  define_setting :job_template, %w[/bin/bash -l -c :job]
 
   class << self
     def schedule(&block)

--- a/lib/cron_kubernetes/configurable.rb
+++ b/lib/cron_kubernetes/configurable.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+module CronKubernetes
+  # Provides configuration settings, with default values, for the gem.
+  module Configurable
+    def configuration
+      yield self
+    end
+
+    # Define a configuration setting and its default value.
+    #
+    # name:    The name of the setting.
+    # default: A default value for the setting. (Optional)
+    def define_setting(name, default = nil)
+      class_variable_set("@@#{name}", default)
+
+      define_class_method "#{name}=" do |value|
+        class_variable_set("@@#{name}", value)
+      end
+
+      define_class_method name do
+        class_variable_get("@@#{name}")
+      end
+    end
+
+    private
+
+    def define_class_method(name, &block)
+      (class << self; self; end).instance_eval do
+        define_method(name, &block)
+      end
+    end
+  end
+end

--- a/lib/cron_kubernetes/cron_job.rb
+++ b/lib/cron_kubernetes/cron_job.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+module CronKubernetes
+  # A single job to run on a given schedule.
+  class CronJob
+    attr_accessor :schedule, :command, :job_manifest, :name
+
+    def initialize(schedule: nil, command: nil, job_manifest: nil, name: nil)
+      @schedule     = schedule
+      @command      = command
+      @job_manifest = job_manifest
+      @name         = name
+    end
+
+    # rubocop:disable Metrics/MethodLength
+    def cron_job_manifest
+      {
+          "apiVersion" => "batch/v1beta1",
+          "kind"       => "CronJob",
+          "metadata"   => {"name" => cron_job_name},
+          "spec"       => {
+              "schedule"    => "*/1 * * * *",
+              "jobTemplate" => {
+                  "metadata" => job_metadata,
+                  "spec"     => job_spec
+              }
+          }
+      }
+    end
+    # rubocop:enable Metrics/MethodLength
+
+    private
+
+    def job_spec
+      spec = job_manifest["spec"].dup
+      first_container = spec["template"]["spec"]["containers"][0]
+      cmd  = command.first
+      args = command[1..-1]
+      first_container["command"] = cmd
+      first_container["args"]    = args
+      spec
+    end
+
+    def job_metadata
+      job_manifest["metadata"]
+    end
+
+    def cron_job_name
+      return name if name
+      return job_manifest["metadata"]["name"] if job_manifest["metadata"]
+      pod_template_name
+    end
+
+    def pod_template_name
+      return nil unless job_manifest["spec"] &&
+            job_manifest["spec"]["template"] &&
+            job_manifest["spec"]["template"]["metadata"]
+      job_manifest["spec"]["template"]["metadata"]["name"]
+    end
+  end
+end

--- a/lib/cron_kubernetes/cron_tab.rb
+++ b/lib/cron_kubernetes/cron_tab.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+module CronKubernetes
+  # The "table" of Kubernetes CronJobs that we manage in the cluster.
+  class CronTab
+    attr_reader :client
+    private :client
+
+    def initialize
+      @client = CronKubernetes::KubernetesClient.new.batch_beta1_client
+    end
+
+    # "Apply" the new configuration
+    #   - remove from cluster any cron_jobs that are no longer in the schedule
+    #   - add new jobs
+    #   - update cron_jobs that exist (deleting a cron_job deletes the job and pod)
+    def update(schedule = nil)
+      schedule ||= CronKubernetes::Scheduler.instance.schedule
+      add, change, remove = diff_schedules(schedule, current_cron_jobs)
+      remove.each { |job| remove_cron_job(job) }
+      add.each { |job| add_cron_job(job) }
+      change.each { |job| update_cron_job(job) }
+    end
+
+    private
+
+    # Define a label for our jobs based on an identifier
+    def label_selector
+      {"cron-kubernetes-identifier" => CronKubernetes.identifier}
+    end
+
+    # Find all k8s CronJobs by our label for the identifier
+    def current_cron_jobs
+      client.get_cron_jobs(label_selector)
+    end
+
+    def diff_schedules(new, existing)
+      new_index = index_cron_jobs(new)
+      existing_index = index_kubernetes_cron_jobs(existing)
+      add_keys    = new_index.keys - existing_index.keys
+      remove_keys = existing_index.keys - new_index.keys
+      change_keys = new_index.keys & existing_index.keys
+
+      [
+          new_index.values_at(*add_keys),
+          new_index.values_at(*change_keys),
+          existing_index.values_at(*remove_keys)
+      ]
+    end
+
+    # Remove a Kubeclient::Resource::CronJob from the Kubernetes cluster
+    def remove_cron_job(job)
+      client.delete_cron_job(job.metadata.name, job.metadata.namespace)
+    end
+
+    # Add a CronKubernetes::CronJob to the Kubernetes cluster
+    def add_cron_job(job)
+      client.create_cron_job(Kubeclient::Resource.new(job.cron_job_manifest))
+    end
+
+    def update_cron_job(job)
+      client.update_cron_job(Kubeclient::Resource.new(job.cron_job_manifest))
+    end
+
+    def index_cron_jobs(jobs)
+      jobs.map { |job| ["#{job.identifier}-#{job.name}", job] }.to_h
+    end
+
+    def index_kubernetes_cron_jobs(jobs)
+      jobs.map { |job| [job.metadata.name, job] }.to_h
+    end
+  end
+end

--- a/lib/cron_kubernetes/kubeclient_context.rb
+++ b/lib/cron_kubernetes/kubeclient_context.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+require "kubeclient"
+
+module CronKubernetes
+  # Create a context for `Kubeclient` depending on the environment.
+  class KubeclientContext
+    class << self
+      def context
+        # TODO: Add ability to load this from config
+
+        if File.exist?("/var/run/secrets/kubernetes.io/serviceaccount/token")
+          # When running in k8s cluster, use the service account secret token and ca bundle
+          well_known_context
+        elsif File.exist?(kubeconfig)
+          # When running in development, use the config file for `kubectl` and default application credentials
+          kubectl_context
+        end
+      end
+
+      private
+
+      def well_known_context
+        Kubeclient::Config::Context.new(
+            "https://kubernetes",
+            "v1",
+            {ca_file: "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"},
+            bearer_token_file: "/var/run/secrets/kubernetes.io/serviceaccount/token"
+        )
+      end
+
+      def kubectl_context
+        config = Kubeclient::Config.read(kubeconfig)
+        auth_options = config.context.auth_options
+
+        auth_options = google_default_application_credentials(config) if auth_options.empty?
+
+        Kubeclient::Config::Context.new(
+            config.context.api_endpoint,
+            config.context.api_version,
+            config.context.ssl_options,
+            auth_options
+        )
+      end
+
+      def kubeconfig
+        File.join(ENV["HOME"], ".kube", "config")
+      end
+
+      # TODO: Move this logic to kubeclient. See abonas/kubeclient#213
+      def google_default_application_credentials(config)
+        return unless defined?(Google) && defined?(Google::Auth)
+
+        _cluster, user = config.send(:fetch_context, config.instance_variable_get(:@kcfg)["current-context"])
+        return {} unless user["auth-provider"] && user["auth-provider"]["name"] == "gcp"
+
+        {bearer_token: new_google_token}
+      end
+
+      def new_google_token
+        scopes = ["https://www.googleapis.com/auth/cloud-platform"]
+        authorization = Google::Auth.get_application_default(scopes)
+        authorization.apply({})
+        authorization.access_token
+      end
+    end
+  end
+end

--- a/lib/cron_kubernetes/kubernetes_client.rb
+++ b/lib/cron_kubernetes/kubernetes_client.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module CronKubernetes
+  # Encapsulate access to Kubernetes API for different API versions.
+  class KubernetesClient
+    def batch_beta1_client
+      @batch_beta1_client ||= client("/apis/batch", "v1beta1")
+    end
+
+    private
+
+    def client(scope, version = nil)
+      context = KubeclientContext.context
+      return unless context
+
+      Kubeclient::Client.new(
+          context.api_endpoint + scope,
+          version || context.api_version,
+          ssl_options:  context.ssl_options,
+          auth_options: context.auth_options
+      )
+    end
+  end
+end

--- a/lib/cron_kubernetes/scheduler.rb
+++ b/lib/cron_kubernetes/scheduler.rb
@@ -3,6 +3,7 @@
 require "singleton"
 
 module CronKubernetes
+  # A singleton that creates and holds the scheduled commands.
   class Scheduler
     include Singleton
     attr_reader :schedule
@@ -11,30 +12,33 @@ module CronKubernetes
       @schedule = []
     end
 
-    def rake(task, schedule:)
+    def rake(task, schedule:, name: nil)
       rake_command = "bundle exec rake #{task} --silent"
       rake_command = "RAILS_ENV=#{rails_env} #{rake_command}" if rails_env
-      @schedule << [schedule, make_command(rake_command)]
+      @schedule << [schedule, make_command(rake_command), name]
     end
 
-    def runner(ruby_command, schedule:)
+    def runner(ruby_command, schedule:, name: nil)
       env = nil
       env = "-e #{rails_env} " if rails_env
       runner_command = "bin/rails runner #{env}'#{ruby_command}'"
-      @schedule << [schedule, make_command(runner_command)]
+      @schedule << [schedule, make_command(runner_command), name]
     end
 
-    def command(command, schedule:)
-      @schedule << [schedule, make_command(command)]
+    def command(command, schedule:, name: nil)
+      @schedule << [schedule, make_command(command), name]
     end
 
     private
 
     def make_command(command)
-      cmd = CronKubernetes.job_template.dup
-      # Use `["..."]` instead of `#sub` because sub thinks "\&" is a back-reference
-      cmd[":job"] = Shellwords.escape("cd #{root} && #{command} #{CronKubernetes.output}")
-      cmd
+      CronKubernetes.job_template.map do |arg|
+        if arg == ":job"
+          "cd #{root} && #{command} #{CronKubernetes.output}"
+        else
+          arg
+        end
+      end
     end
 
     def rails_env

--- a/lib/cron_kubernetes/scheduler.rb
+++ b/lib/cron_kubernetes/scheduler.rb
@@ -15,18 +15,18 @@ module CronKubernetes
     def rake(task, schedule:, name: nil)
       rake_command = "bundle exec rake #{task} --silent"
       rake_command = "RAILS_ENV=#{rails_env} #{rake_command}" if rails_env
-      @schedule << [schedule, make_command(rake_command), name]
+      @schedule << CronJob.new(schedule: schedule, command: make_command(rake_command), name: name)
     end
 
     def runner(ruby_command, schedule:, name: nil)
       env = nil
       env = "-e #{rails_env} " if rails_env
       runner_command = "bin/rails runner #{env}'#{ruby_command}'"
-      @schedule << [schedule, make_command(runner_command), name]
+      @schedule << CronJob.new(schedule: schedule, command: make_command(runner_command), name: name)
     end
 
     def command(command, schedule:, name: nil)
-      @schedule << [schedule, make_command(command), name]
+      @schedule << CronJob.new(schedule: schedule, command: make_command(command), name: name)
     end
 
     private

--- a/lib/cron_kubernetes/scheduler.rb
+++ b/lib/cron_kubernetes/scheduler.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require "singleton"
+
+module CronKubernetes
+  class Scheduler
+    include Singleton
+    attr_reader :schedule
+
+    def initialize
+      @schedule = []
+    end
+
+    def rake(task, schedule:)
+      rake_command = "bundle exec rake #{task} --silent"
+      rake_command = "RAILS_ENV=#{rails_env} #{rake_command}" if rails_env
+      @schedule << [schedule, make_command(rake_command)]
+    end
+
+    def runner(ruby_command, schedule:)
+      env = nil
+      env = "-e #{rails_env} " if rails_env
+      runner_command = "bin/rails runner #{env}'#{ruby_command}'"
+      @schedule << [schedule, make_command(runner_command)]
+    end
+
+    def command(command, schedule:)
+      @schedule << [schedule, make_command(command)]
+    end
+
+    private
+
+    def make_command(command)
+      cmd = CronKubernetes.job_template.dup
+      # Use `["..."]` instead of `#sub` because sub thinks "\&" is a back-reference
+      cmd[":job"] = Shellwords.escape("cd #{root} && #{command} #{CronKubernetes.output}")
+      cmd
+    end
+
+    def rails_env
+      ENV["RAILS_ENV"]
+    end
+
+    def root
+      return Rails.root if defined? Rails
+      Dir.pwd
+    end
+  end
+end

--- a/spec/cron_kubernetes/cron_job_spec.rb
+++ b/spec/cron_kubernetes/cron_job_spec.rb
@@ -1,0 +1,156 @@
+# frozen_string_literal: true
+
+RSpec.describe CronKubernetes::CronJob do
+  subject { CronKubernetes::CronJob.new }
+
+  let(:manifest) do
+    YAML.safe_load <<~MANIFEST
+      apiVersion: batch/v1
+      kind: Job
+      spec:
+        template:
+          spec:
+            containers:
+            - name: hello
+              image: busybox
+            restartPolicy: OnFailure
+    MANIFEST
+  end
+
+  context "initialization" do
+    it "accepts no parameters" do
+      expect { CronKubernetes::CronJob.new }.not_to raise_error
+    end
+
+    it "accepts schedule, command, job_manifest, name parameters" do
+      job = CronKubernetes::CronJob.new(
+          schedule:     "30 0 * * *",
+          command:      "/bin/bash -l -c ls\\ -l",
+          job_manifest: manifest,
+          name:         "cron-job"
+      )
+      expect(job.schedule).to eq "30 0 * * *"
+      expect(job.command).to eq "/bin/bash -l -c ls\\ -l"
+      expect(job.job_manifest).to eq manifest
+    end
+  end
+
+  context "accessors" do
+    it "has a schedule accessor" do
+      subject.schedule = "30 0 * * *"
+      expect(subject.schedule).to eq "30 0 * * *"
+    end
+
+    it "has a command accessor" do
+      subject.schedule = "/bin/bash -l -c ls\\ -l"
+      expect(subject.schedule).to eq "/bin/bash -l -c ls\\ -l"
+    end
+
+    it "has a job_manifest accessor" do
+      subject.job_manifest = manifest
+      expect(subject.job_manifest).to eq manifest
+    end
+
+    it "has a name accessor" do
+      subject.name = "cron-job"
+      expect(subject.name).to eq "cron-job"
+    end
+  end
+
+  context "#cron_job_manifest" do
+    subject do
+      CronKubernetes::CronJob.new(
+          schedule:     "*/1 * * * *",
+          command:      ["/bin/bash", "-l", "-c", "echo Hello from the Kubernetes cluster"],
+          job_manifest: manifest,
+          name:         "hello"
+      )
+    end
+
+    it "generates a Kubernetes CronJob manifest for the scheduled command" do
+      # rubocop:disable Layout/TrailingWhitespace
+      expect(subject.cron_job_manifest.to_yaml).to eq <<~MANIFEST
+        ---
+        apiVersion: batch/v1beta1
+        kind: CronJob
+        metadata:
+          name: hello
+        spec:
+          schedule: "*/1 * * * *"
+          jobTemplate:
+            metadata: 
+            spec:
+              template:
+                spec:
+                  containers:
+                  - name: hello
+                    image: busybox
+                    command: "/bin/bash"
+                    args:
+                    - "-l"
+                    - "-c"
+                    - echo Hello from the Kubernetes cluster
+                  restartPolicy: OnFailure
+      MANIFEST
+      # rubocop:enable Layout/TrailingWhitespace
+    end
+
+    context "when no name is provided" do
+      subject do
+        CronKubernetes::CronJob.new(
+            schedule:     "*/1 * * * *",
+            command:      ["/bin/bash", "-l", "-c", "echo Hello from the Kubernetes cluster"],
+            job_manifest: manifest
+        )
+      end
+
+      context "but exists in the Job template metadata" do
+        let(:manifest) do
+          YAML.safe_load <<~MANIFEST
+            apiVersion: batch/v1
+            kind: Job
+            metadata:
+              name: hello-job
+            spec:
+              template:
+                spec:
+                  containers:
+                  - name: hello
+                    image: busybox
+                  restartPolicy: OnFailure
+          MANIFEST
+        end
+
+        it "pulls the name from the Job metadata" do
+          expect(subject.cron_job_manifest["metadata"]["name"]).to eq "hello-job"
+          expect(subject.cron_job_manifest["spec"]["jobTemplate"]["metadata"]["name"]).to eq "hello-job"
+        end
+      end
+
+      context "but exists in the Pod template metadata" do
+        let(:manifest) do
+          YAML.safe_load <<~MANIFEST
+            apiVersion: batch/v1
+            kind: Job
+            spec:
+              template:
+                metadata:
+                  name: hello-pod
+                spec:
+                  containers:
+                  - name: hello
+                    image: busybox
+                  restartPolicy: OnFailure
+          MANIFEST
+        end
+
+        it "pulls the name from the Pod metadata" do
+          expect(subject.cron_job_manifest["metadata"]["name"]).to eq "hello-pod"
+          job_template = subject.cron_job_manifest["spec"]["jobTemplate"]
+          pod_template = job_template["spec"]["template"]
+          expect(pod_template["metadata"]["name"]).to eq "hello-pod"
+        end
+      end
+    end
+  end
+end

--- a/spec/cron_kubernetes/cron_tab_spec.rb
+++ b/spec/cron_kubernetes/cron_tab_spec.rb
@@ -1,0 +1,100 @@
+# frozen_string_literal: true
+
+RSpec.describe CronKubernetes::CronTab do
+  subject { CronKubernetes::CronTab.new }
+
+  let(:client) { stub "Kubeclient::Client" }
+  let(:job_manifest) do
+    YAML.safe_load <<~MANIFEST
+      apiVersion: batch/v1
+      kind: Job
+      spec:
+        template:
+          spec:
+            containers:
+            - image: ubuntu
+            restartPolicy: OnFailure
+    MANIFEST
+  end
+  let(:cron_job_manifest) do
+    {
+        apiVersion: "batch/v1beta1",
+        kind:       "CronJob",
+        metadata:   {
+            name:      "spec-minutely",
+            namespace: "default",
+            labels:    {"cron-kubernetes-identifier": "spec"}
+        },
+        spec:       {
+            schedule:    "*/1 * * * *",
+            jobTemplate: {
+                metadata: nil,
+                spec:     {
+                    template: {
+                        spec: {
+                            containers:    [{image: "ubuntu", command: "ls -l"}],
+                            restartPolicy: "OnFailure"
+                        }
+                    }
+                }
+            }
+        }
+    }
+  end
+  let(:job) do
+    CronKubernetes::CronJob.new(
+        schedule:     "*/1 * * * *",
+        command:      "ls -l",
+        job_manifest: job_manifest,
+        name:         "minutely",
+        identifier:   "spec"
+    )
+  end
+  let(:cron_job) do
+    Kubeclient::Resource.new(cron_job_manifest)
+  end
+
+  before do
+    CronKubernetes::KubernetesClient.any_instance.stubs(:batch_beta1_client).returns client
+    client.stubs(:get_cron_jobs).returns existing
+    CronKubernetes::Scheduler.instance.stubs(:schedule).returns schedule
+  end
+
+  context "#udpate" do
+    context "when new jobs are added to the schedule" do
+      let(:existing) { [] }
+      let(:schedule) { [job] }
+
+      it "creates the Kubernetes cron job" do
+        client.expects(:create_cron_job).with do |resource|
+          resource.kind == "CronJob" &&
+              resource.metadata.name == "spec-minutely"
+        end
+        subject.update
+      end
+    end
+
+    context "when jobs are removed from the schedule" do
+      let(:existing) { [cron_job] }
+      let(:schedule) { [] }
+
+      it "removes the Kubernetes cron job" do
+        client.expects(:delete_cron_job).with("spec-minutely", "default")
+        subject.update
+      end
+    end
+
+    context "for jobs that have not changed in the schedule" do
+      let(:existing) { [cron_job] }
+      let(:schedule) { [job] }
+
+      it "updates them to ensure they are up-to-date" do
+        client.expects(:update_cron_job).with do |resource|
+          resource.kind == "CronJob" &&
+              resource.metadata.name == "spec-minutely"
+        end
+        subject.update
+      end
+    end
+  end
+end

--- a/spec/cron_kubernetes/scheduler_spec.rb
+++ b/spec/cron_kubernetes/scheduler_spec.rb
@@ -27,18 +27,18 @@ RSpec.describe CronKubernetes::Scheduler do
 
         action
         expect(subject.schedule.length).to eq 1
-        command = subject.schedule.first.last
-        expect(command).to end_with " 2\\>\\&1"
+        command = subject.schedule.first[1]
+        expect(command.join).to end_with " 2>&1"
       end
     end
 
     it "includes the job template" do
-      expect(CronKubernetes.job_template).to eq "/bin/bash -l -c :job"
+      expect(CronKubernetes.job_template).to eq %w[/bin/bash -l -c :job]
 
       action
       expect(subject.schedule.length).to eq 1
-      command = subject.schedule.first.last
-      expect(command).to start_with "/bin/bash -l -c "
+      command = subject.schedule.first[1]
+      expect(command).to start_with %w[/bin/bash -l -c]
     end
   end
 
@@ -50,14 +50,14 @@ RSpec.describe CronKubernetes::Scheduler do
       expect(subject.schedule.length).to eq 1
       cron, command = *subject.schedule.first
       expect(cron).to eq "0 20 1 * *"
-      expect(command).to include "bundle\\ exec\\ rake\\ audit:state"
+      expect(command.join).to include "bundle exec rake audit:state"
     end
 
     it "properly escapes quotes in the rake task" do
       subject.rake("audit:state MAIL_TO='notice@example.com'", schedule: "0 20 1 * *")
       expect(subject.schedule.length).to eq 1
-      command = subject.schedule.first.last
-      expect(command).to include "MAIL_TO\\=\\'notice@example.com\\'"
+      command = subject.schedule.first[1]
+      expect(command.join).to include "MAIL_TO='notice@example.com'"
     end
 
     context "when RAILS_ENV is defined" do
@@ -73,8 +73,8 @@ RSpec.describe CronKubernetes::Scheduler do
       it "includes the RAILS_ENV" do
         action
         expect(subject.schedule.length).to eq 1
-        command = subject.schedule.first.last
-        expect(command).to include "RAILS_ENV\\=production"
+        command = subject.schedule.first[1]
+        expect(command.join).to include "RAILS_ENV=production"
       end
     end
 
@@ -82,8 +82,8 @@ RSpec.describe CronKubernetes::Scheduler do
       it "does not include the RAILS_ENV" do
         action
         expect(subject.schedule.length).to eq 1
-        command = subject.schedule.first.last
-        expect(command).not_to include "RAILS_ENV"
+        command = subject.schedule.first[1]
+        expect(command.join).not_to include "RAILS_ENV"
       end
     end
 
@@ -98,9 +98,8 @@ RSpec.describe CronKubernetes::Scheduler do
       expect(subject.schedule.length).to eq 1
       cron, command = *subject.schedule.first
       expect(cron).to eq "30 3 * * *"
-      expect(command).to include "bin/rails\\ runner\\ \\'puts\\ CronKubernetes.name\\'"
+      expect(command.join).to include "bin/rails runner 'puts CronKubernetes.name'"
     end
-
 
     context "when RAILS_ENV is defined" do
       before do
@@ -115,8 +114,8 @@ RSpec.describe CronKubernetes::Scheduler do
       it "includes the -e parameter" do
         action
         expect(subject.schedule.length).to eq 1
-        command = subject.schedule.first.last
-        expect(command).to include "\\ -e\\ production\\ "
+        command = subject.schedule.first[1]
+        expect(command.join).to include " -e production "
       end
     end
 
@@ -124,8 +123,8 @@ RSpec.describe CronKubernetes::Scheduler do
       it "does not include the RAILS_ENV" do
         action
         expect(subject.schedule.length).to eq 1
-        command = subject.schedule.first.last
-        expect(command).not_to include "\\ -e\\ "
+        command = subject.schedule.first[1]
+        expect(command.join).not_to include " -e "
       end
     end
 
@@ -140,7 +139,7 @@ RSpec.describe CronKubernetes::Scheduler do
       expect(subject.schedule.length).to eq 1
       cron, command = *subject.schedule.first
       expect(cron).to eq "0 1 1 1 *"
-      expect(command).to include "ls\\ -l"
+      expect(command.join).to include "ls -l"
     end
 
     include_examples "common"

--- a/spec/cron_kubernetes/scheduler_spec.rb
+++ b/spec/cron_kubernetes/scheduler_spec.rb
@@ -1,0 +1,149 @@
+# frozen_string_literal: true
+
+RSpec.describe CronKubernetes::Scheduler do
+  subject { CronKubernetes::Scheduler.instance }
+
+  after do
+    subject.schedule.clear
+  end
+
+  shared_examples "common" do
+    context "when output is configured" do
+      before do
+        @output = CronKubernetes.output
+        CronKubernetes.configuration do |config|
+          config.output = "2>&1"
+        end
+      end
+
+      after do
+        CronKubernetes.configuration do |config|
+          config.output = @output
+        end
+      end
+
+      it "includes a redirection for the output" do
+        expect(CronKubernetes.output).to eq "2>&1"
+
+        action
+        expect(subject.schedule.length).to eq 1
+        command = subject.schedule.first.last
+        expect(command).to end_with " 2\\>\\&1"
+      end
+    end
+
+    it "includes the job template" do
+      expect(CronKubernetes.job_template).to eq "/bin/bash -l -c :job"
+
+      action
+      expect(subject.schedule.length).to eq 1
+      command = subject.schedule.first.last
+      expect(command).to start_with "/bin/bash -l -c "
+    end
+  end
+
+  context "#rake" do
+    let(:action) { subject.rake("audit:state", schedule: "0 20 1 * *") }
+
+    it "adds a rake task to the cron list" do
+      action
+      expect(subject.schedule.length).to eq 1
+      cron, command = *subject.schedule.first
+      expect(cron).to eq "0 20 1 * *"
+      expect(command).to include "bundle\\ exec\\ rake\\ audit:state"
+    end
+
+    it "properly escapes quotes in the rake task" do
+      subject.rake("audit:state MAIL_TO='notice@example.com'", schedule: "0 20 1 * *")
+      expect(subject.schedule.length).to eq 1
+      command = subject.schedule.first.last
+      expect(command).to include "MAIL_TO\\=\\'notice@example.com\\'"
+    end
+
+    context "when RAILS_ENV is defined" do
+      before do
+        @rails_env = ENV["RAILS_ENV"]
+        ENV["RAILS_ENV"] = "production"
+      end
+
+      after do
+        ENV["RAILS_ENV"] = @rails_env
+      end
+
+      it "includes the RAILS_ENV" do
+        action
+        expect(subject.schedule.length).to eq 1
+        command = subject.schedule.first.last
+        expect(command).to include "RAILS_ENV\\=production"
+      end
+    end
+
+    context "when RAILS_ENV is not defined" do
+      it "does not include the RAILS_ENV" do
+        action
+        expect(subject.schedule.length).to eq 1
+        command = subject.schedule.first.last
+        expect(command).not_to include "RAILS_ENV"
+      end
+    end
+
+    include_examples "common"
+  end
+
+  context "#runner" do
+    let(:action) { subject.runner("puts CronKubernetes.name", schedule: "30 3 * * *") }
+
+    it "adds a runner task to the cron list that invokes the code in the block" do
+      action
+      expect(subject.schedule.length).to eq 1
+      cron, command = *subject.schedule.first
+      expect(cron).to eq "30 3 * * *"
+      expect(command).to include "bin/rails\\ runner\\ \\'puts\\ CronKubernetes.name\\'"
+    end
+
+
+    context "when RAILS_ENV is defined" do
+      before do
+        @rails_env = ENV["RAILS_ENV"]
+        ENV["RAILS_ENV"] = "production"
+      end
+
+      after do
+        ENV["RAILS_ENV"] = @rails_env
+      end
+
+      it "includes the -e parameter" do
+        action
+        expect(subject.schedule.length).to eq 1
+        command = subject.schedule.first.last
+        expect(command).to include "\\ -e\\ production\\ "
+      end
+    end
+
+    context "when RAILS_ENV is not defined" do
+      it "does not include the RAILS_ENV" do
+        action
+        expect(subject.schedule.length).to eq 1
+        command = subject.schedule.first.last
+        expect(command).not_to include "\\ -e\\ "
+      end
+    end
+
+    include_examples "common"
+  end
+
+  context "#command" do
+    let(:action) { subject.command("ls -l", schedule: "0 1 1 1 *") }
+
+    it "adds any shell command to the cron list" do
+      action
+      expect(subject.schedule.length).to eq 1
+      cron, command = *subject.schedule.first
+      expect(cron).to eq "0 1 1 1 *"
+      expect(command).to include "ls\\ -l"
+    end
+
+    include_examples "common"
+  end
+
+end

--- a/spec/cron_kubernetes/scheduler_spec.rb
+++ b/spec/cron_kubernetes/scheduler_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe CronKubernetes::Scheduler do
 
         action
         expect(subject.schedule.length).to eq 1
-        command = subject.schedule.first[1]
+        command = subject.schedule.first.command
         expect(command.join).to end_with " 2>&1"
       end
     end
@@ -37,7 +37,7 @@ RSpec.describe CronKubernetes::Scheduler do
 
       action
       expect(subject.schedule.length).to eq 1
-      command = subject.schedule.first[1]
+      command = subject.schedule.first.command
       expect(command).to start_with %w[/bin/bash -l -c]
     end
   end
@@ -48,15 +48,15 @@ RSpec.describe CronKubernetes::Scheduler do
     it "adds a rake task to the cron list" do
       action
       expect(subject.schedule.length).to eq 1
-      cron, command = *subject.schedule.first
-      expect(cron).to eq "0 20 1 * *"
-      expect(command.join).to include "bundle exec rake audit:state"
+      job = subject.schedule.first
+      expect(job.schedule).to eq "0 20 1 * *"
+      expect(job.command.join).to include "bundle exec rake audit:state"
     end
 
     it "properly escapes quotes in the rake task" do
       subject.rake("audit:state MAIL_TO='notice@example.com'", schedule: "0 20 1 * *")
       expect(subject.schedule.length).to eq 1
-      command = subject.schedule.first[1]
+      command = subject.schedule.first.command
       expect(command.join).to include "MAIL_TO='notice@example.com'"
     end
 
@@ -73,7 +73,7 @@ RSpec.describe CronKubernetes::Scheduler do
       it "includes the RAILS_ENV" do
         action
         expect(subject.schedule.length).to eq 1
-        command = subject.schedule.first[1]
+        command = subject.schedule.first.command
         expect(command.join).to include "RAILS_ENV=production"
       end
     end
@@ -82,7 +82,7 @@ RSpec.describe CronKubernetes::Scheduler do
       it "does not include the RAILS_ENV" do
         action
         expect(subject.schedule.length).to eq 1
-        command = subject.schedule.first[1]
+        command = subject.schedule.first.command
         expect(command.join).not_to include "RAILS_ENV"
       end
     end
@@ -96,9 +96,9 @@ RSpec.describe CronKubernetes::Scheduler do
     it "adds a runner task to the cron list that invokes the code in the block" do
       action
       expect(subject.schedule.length).to eq 1
-      cron, command = *subject.schedule.first
-      expect(cron).to eq "30 3 * * *"
-      expect(command.join).to include "bin/rails runner 'puts CronKubernetes.name'"
+      job = subject.schedule.first
+      expect(job.schedule).to eq "30 3 * * *"
+      expect(job.command.join).to include "bin/rails runner 'puts CronKubernetes.name'"
     end
 
     context "when RAILS_ENV is defined" do
@@ -114,7 +114,7 @@ RSpec.describe CronKubernetes::Scheduler do
       it "includes the -e parameter" do
         action
         expect(subject.schedule.length).to eq 1
-        command = subject.schedule.first[1]
+        command = subject.schedule.first.command
         expect(command.join).to include " -e production "
       end
     end
@@ -123,7 +123,7 @@ RSpec.describe CronKubernetes::Scheduler do
       it "does not include the RAILS_ENV" do
         action
         expect(subject.schedule.length).to eq 1
-        command = subject.schedule.first[1]
+        command = subject.schedule.first.command
         expect(command.join).not_to include " -e "
       end
     end
@@ -137,9 +137,9 @@ RSpec.describe CronKubernetes::Scheduler do
     it "adds any shell command to the cron list" do
       action
       expect(subject.schedule.length).to eq 1
-      cron, command = *subject.schedule.first
-      expect(cron).to eq "0 1 1 1 *"
-      expect(command.join).to include "ls -l"
+      job = subject.schedule.first
+      expect(job.schedule).to eq "0 1 1 1 *"
+      expect(job.command.join).to include "ls -l"
     end
 
     include_examples "common"

--- a/spec/cron_kubernetes_spec.rb
+++ b/spec/cron_kubernetes_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe CronKubernetes do
   end
 
   context "::configuration" do
-    context "job_template" do
+    context "manifest" do
       it "defaults nothing" do
         expect(CronKubernetes.output).to be_nil
       end
@@ -59,14 +59,14 @@ RSpec.describe CronKubernetes do
 
   context "job_template" do
     it "defaults to a bash shell" do
-      expect(CronKubernetes.job_template).to eq "/bin/bash -l -c :job"
+      expect(CronKubernetes.job_template).to eq %w[/bin/bash -l -c :job]
     end
 
     context do
       before do
         @job_template = CronKubernetes.job_template
         CronKubernetes.configuration do |config|
-          config.job_template = "/bin/zsh -c :job"
+          config.job_template = %w[/bin/zsh -c :job]
         end
       end
 
@@ -77,7 +77,7 @@ RSpec.describe CronKubernetes do
       end
 
       it "can be configured for anything" do
-        expect(CronKubernetes.job_template).to eq("/bin/zsh -c :job")
+        expect(CronKubernetes.job_template).to eq(%w[/bin/zsh -c :job])
       end
     end
   end

--- a/spec/cron_kubernetes_spec.rb
+++ b/spec/cron_kubernetes_spec.rb
@@ -4,4 +4,95 @@ RSpec.describe CronKubernetes do
   it "has a version number" do
     expect(CronKubernetes::VERSION).not_to be nil
   end
+
+  context "::configuration" do
+    context "job_template" do
+      it "defaults nothing" do
+        expect(CronKubernetes.output).to be_nil
+      end
+
+      context do
+        before do
+          @manifest = CronKubernetes.manifest
+          CronKubernetes.configuration do |config|
+            config.manifest = {spec: :template}
+          end
+        end
+
+        after do
+          CronKubernetes.configuration do |config|
+            config.manifest = @manifest
+          end
+        end
+
+        it "can be configured for anything" do
+          expect(CronKubernetes.manifest).to eq(spec: :template)
+        end
+      end
+    end
+
+    context "output" do
+      it "defaults nothing" do
+        expect(CronKubernetes.output).to be_nil
+      end
+
+      context do
+        before do
+          @output = CronKubernetes.output
+          CronKubernetes.configuration do |config|
+            config.output = ">> log"
+          end
+        end
+
+        after do
+          CronKubernetes.configuration do |config|
+            config.output = @output
+          end
+        end
+
+        it "can be configured for anything" do
+          expect(CronKubernetes.output).to eq(">> log")
+        end
+      end
+    end
+  end
+
+  context "job_template" do
+    it "defaults to a bash shell" do
+      expect(CronKubernetes.job_template).to eq "/bin/bash -l -c :job"
+    end
+
+    context do
+      before do
+        @job_template = CronKubernetes.job_template
+        CronKubernetes.configuration do |config|
+          config.job_template = "/bin/zsh -c :job"
+        end
+      end
+
+      after do
+        CronKubernetes.configuration do |config|
+          config.job_template = @job_template
+        end
+      end
+
+      it "can be configured for anything" do
+        expect(CronKubernetes.job_template).to eq("/bin/zsh -c :job")
+      end
+    end
+  end
+
+  context "::schedule" do
+    after do
+      CronKubernetes::Scheduler.instance.schedule.clear
+    end
+
+    it "invokes the block in a CronKubernetes::Scheduler instance context" do
+      expect do
+        CronKubernetes.schedule do
+          nil
+        end
+      end.not_to raise_error
+    end
+  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,6 +3,10 @@
 require "bundler/setup"
 require "cron_kubernetes"
 
+# Requires supporting ruby files with custom matchers and macros, etc,
+# in spec/support/ and its subdirectories.
+Dir[File.expand_path("support/**/*.rb", __dir__)].each { |f| require f }
+
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure
   config.example_status_persistence_file_path = ".rspec_status"
@@ -13,4 +17,7 @@ RSpec.configure do |config|
   config.expect_with :rspec do |c|
     c.syntax = :expect
   end
+
+  config.mock_with :mocha
+  config.order = "random"
 end


### PR DESCRIPTION
Initial code commit.

This provides a ruby gem to manage Kubernetes CronJobs. Similar to how the `whenever` gem allows us to manage `crontab` files. This enables us to write out scheduled tasks and have them implemented as CronJobs in the Kubernetes cluster. 

In a cluster environment this has a lot of advantages over running a container to host crontab:
- The CronJobs are managed by Kubernetes, so we don't have to keep a container running for it.
- Each CronJob spawns a Job at the scheduled time. The Job spawns a Pod. When the containers in the pod complete (without error), the Job completes. Long running Jobs won't be affected by code deployment because they won't be changed.
- If a Job fails, Kubernetes will automatically restart it.
- Each Job is isolated to it's own container.