### PR TITLE
Fix issue where all cronjobs in the cluster were deleted

### DIFF
--- a/lib/cron_kubernetes/cron_tab.rb
+++ b/lib/cron_kubernetes/cron_tab.rb
@@ -26,7 +26,7 @@ module CronKubernetes
 
     # Define a label for our jobs based on an identifier
     def label_selector
-      {"cron-kubernetes-identifier" => CronKubernetes.identifier}
+      {label_selector: "cron-kubernetes-identifier=#{CronKubernetes.identifier}"}
     end
 
     # Find all k8s CronJobs by our label for the identifier


### PR DESCRIPTION
Internal issue #160941409

If you update the schedule in a cluster that has Kubernetes CronJobs from another schedule, it would remove _all_ the other CronJobs. The behavior was that it was only supposed to be making changes o the CronJobs for this particular schedule, as defined by the `identifier` in the configuration.

The issue was that `kubeclient` expects the label selector details to be passed to the `get`-type methods as the `label_selector`-named parameter, not as the first argument. 

This resolves that and adds a test to make sure that the correct call is being performed.

I tested this manually by creating a set of cron jobs from one schedule in a cluster, then applying the a differently-named schedule to the cluster and ensuring that it only changed items in the named schedule.