### PR TITLE
change syntax to pass arguments for ruby 3.2.2

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,7 +2,7 @@ AllCops:
   Exclude:
     - "gemfiles/*"
   SuggestExtensions: false
-  TargetRubyVersion: 2.7
+  TargetRubyVersion: 3.2
 
 Documentation:
   Exclude:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# v3.0.0
+- Change syntax for ruby 3.2.2
+
 # v2.0.0
 **Breaking Change:**
 - Requires ruby 2.7 or later

--- a/cron-kubernetes.gemspec
+++ b/cron-kubernetes.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |spec|
   spec.description   = "Configure and deploy Kubernetes CronJobs from ruby with a single schedule."
   spec.homepage      = "https://github.com/keylimetoolbox/cron-kubernetes"
   spec.license       = "MIT"
-  spec.required_ruby_version = ">= 2.7"
+  spec.required_ruby_version = ">= 3.2"
 
   spec.files = `git ls-files -z`.split("\x0").reject do |f|
     f.match(%r{^(test|spec|features)/})

--- a/lib/cron_kubernetes/context/well_known.rb
+++ b/lib/cron_kubernetes/context/well_known.rb
@@ -18,7 +18,7 @@ module CronKubernetes
           "v1",
           namespace,
           auth_options: {bearer_token_file: TOKEN_FILE},
-          ssl_options:  ssl_options
+          ssl_options:
         )
       end
 

--- a/lib/cron_kubernetes/kubernetes_client.rb
+++ b/lib/cron_kubernetes/kubernetes_client.rb
@@ -17,7 +17,7 @@ module CronKubernetes
       return CronKubernetes.kubeclient if CronKubernetes.kubeclient
       return unless context
 
-      Kubeclient::Client.new(context.endpoint + scope, version || context.version, context.options)
+      Kubeclient::Client.new(context.endpoint + scope, version || context.version, **context.options)
     end
 
     def context

--- a/lib/cron_kubernetes/scheduler.rb
+++ b/lib/cron_kubernetes/scheduler.rb
@@ -44,10 +44,10 @@ module CronKubernetes
 
     def new_cron_job(schedule, command, name)
       CronJob.new(
-        schedule:     schedule,
+        schedule:,
         command:      make_command(command),
         job_manifest: CronKubernetes.manifest,
-        name:         name,
+        name:,
         identifier:   @identifier
       )
     end

--- a/lib/cron_kubernetes/version.rb
+++ b/lib/cron_kubernetes/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module CronKubernetes
-  VERSION = "2.0.0"
+  VERSION = "3.0.0"
 end

--- a/spec/cron_kubernetes/cron_tab_spec.rb
+++ b/spec/cron_kubernetes/cron_tab_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe CronKubernetes::CronTab do
     CronKubernetes::CronJob.new(
       schedule:     "*/1 * * * *",
       command:      "ls -l",
-      job_manifest: job_manifest,
+      job_manifest:,
       name:         "minutely",
       identifier:   "spec"
     )


### PR DESCRIPTION
## Description
Ruby 3.2.2 has a new syntex to pass arguments.

## Work Done
- Add `**` to pass arguments options in ` Kubeclient::Client.new`
- Bump version from `2.0.0` to `3.0.0`